### PR TITLE
Switch from Nextstrain CLI on AWS Batch to just plain AWS Batch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.idea/
+.snakemake/
+auspice/
+benchmarks/
+data.nextstrain.org/
+logs/
+results/
+Terraform/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM nextstrain/base:latest
+
+WORKDIR /covid-19-puerto-rico-nextstrain
+
+# Essential upstream content
+COPY LICENSE Snakefile ./
+COPY defaults/ defaults/
+COPY scripts/ scripts/
+COPY workflow/ workflow/
+COPY nextstrain_profiles/ nextstrain_profiles/
+
+# Non-essential upstream content
+#COPY my_profiles/ my_profiles/
+#COPY tests/ tests/
+#COPY data/ data/
+
+# Our repo's actual original content
+COPY docker-entrypoint.sh ./
+COPY puerto-rico_profiles/ puerto-rico_profiles/
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Terraform/.gitignore
+++ b/Terraform/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+Backend.tf

--- a/Terraform/.terraform.lock.hcl
+++ b/Terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.63.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:Z+2GvXLgqQ/uPMH8dv+dXJ/t+jd6sriYjhCJS6kSO6g=",
+    "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
+    "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
+    "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
+    "zh:632cb5e2d9d5041875f57174236eafe5b05dbf26750c1041ab57eb08c5369fe2",
+    "zh:7cfeaf5bde1b28bd010415af1f3dc494680a8374f1a26ec19db494d99938cc4e",
+    "zh:99d871606b67c8aefce49007315de15736b949c09a9f8f29ad8af1e9ce383ed3",
+    "zh:c4fc8539ffe90df5c7ae587fde495fac6bc0186fec2f2713a8988a619cef265f",
+    "zh:d0a26493206575c99ca221d78fe64f96a8fbcebe933af92eea6b39168c1f1c1d",
+    "zh:e156fdc964fdd4a7586ec15629e20d2b06295b46b4962428006e088145db07d6",
+    "zh:eb04fc80f652b5c92f76822f0fec1697581543806244068506aed69e1bb9b2af",
+    "zh:f5638a533cf9444f7d02b5527446cdbc3b2eab8bcc4ec4b0ca32035fe6f479d3",
+  ]
+}

--- a/Terraform/AWS.tf
+++ b/Terraform/AWS.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "admin"
+  region  = "us-west-2"
+}
+
+data "aws_region" "current" {}
+data "aws_availability_zones" "available" {}

--- a/Terraform/Batch.tf
+++ b/Terraform/Batch.tf
@@ -1,0 +1,101 @@
+resource "aws_batch_job_definition" "nextstrain_job" {
+  name = var.project_name
+  tags = {
+    Project = var.project_name
+  }
+  type = "container"
+  platform_capabilities = ["FARGATE"]
+
+  container_properties = jsonencode({
+    image = "${data.aws_ecr_image.nextstrain_job.registry_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/${data.aws_ecr_image.nextstrain_job.repository_name}:${data.aws_ecr_image.nextstrain_job.image_tag}"
+    executionRoleArn = aws_iam_role.ecs_task_role.arn
+    jobRoleArn = aws_iam_role.ecs_job_role.arn
+    fargatePlatformConfiguration = {
+      "platformVersion": "LATEST"
+    },
+    resourceRequirements = [
+      {"type": "VCPU", "value": tostring(var.vcpus)},
+      {"type": "MEMORY", "value": tostring(var.memory)}
+    ]
+    networkConfiguration = {
+      "assignPublicIp": "ENABLED"
+    }
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+          "awslogs-group" = aws_cloudwatch_log_group.log_group.name,
+          "awslogs-region" = var.aws_region,
+          "awslogs-stream-prefix" = "batch"
+      }
+    }
+    environment = [
+      {
+        name = "S3_DESTINATION",
+        value = "s3://${data.aws_s3_bucket.main_bucket.bucket}/auspice"
+      },
+      {
+        name = "DISTRIBUTION_ID",
+        value = aws_cloudfront_distribution.s3_distribution.id
+      }
+    ]
+  })
+
+  retry_strategy {
+    attempts = var.retry_attempts
+  }
+
+  timeout {
+    attempt_duration_seconds = var.timeout_seconds
+  }
+}
+
+resource "aws_batch_compute_environment" "nextstrain" {
+  compute_environment_name = "${var.project_name}-compute-environment"
+  tags = {
+    Project = var.project_name
+  }
+
+  compute_resources {
+    max_vcpus = 16
+
+    security_group_ids = [
+      aws_security_group.outbound_only.id
+    ]
+
+    subnets = aws_subnet.subnet.*.id
+
+    type = "FARGATE"
+  }
+
+  service_role = aws_iam_role.batch_service_role.arn
+  type         = "MANAGED"
+  depends_on   = [aws_iam_role_policy_attachment.batch_service_role]
+}
+
+
+resource "aws_batch_job_queue" "nextstrain-queue" {
+  # Nextstrain CLI expects this exact name
+  name     = "nextstrain-job-queue"
+  tags = {
+    Project = var.project_name
+  }
+  state    = "ENABLED"
+  priority = 1
+  compute_environments = [
+    aws_batch_compute_environment.nextstrain.arn
+  ]
+}
+
+
+
+/********************************************
+ * Cloudwatch logging
+ */
+
+resource "aws_cloudwatch_log_group" "log_group" {
+  name = var.project_name
+  retention_in_days = 30
+  tags = {
+    Project = var.project_name
+  }
+}

--- a/Terraform/Cloudfront.tf
+++ b/Terraform/Cloudfront.tf
@@ -1,0 +1,85 @@
+locals {
+  s3_origin_id = "covid-19-puerto-rico"
+}
+
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+  comment = "covid-19-puerto-rico-web"
+}
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  tags = {
+    Project = var.project_name
+  }
+
+  origin {
+    domain_name = data.aws_s3_bucket.main_bucket.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+//  default_root_object = "index.html"
+
+  logging_config {
+    bucket          = data.aws_s3_bucket.logs_bucket.bucket_domain_name
+    prefix          = "www"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+
+# to get the Cloud front URL if doamin/alias is not configured
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.s3_distribution.domain_name
+}
+
+
+data "aws_iam_policy_document" "cloudfront_access_to_main_bucket" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${data.aws_s3_bucket.main_bucket.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudfront_access_to_main_bucket" {
+  bucket = data.aws_s3_bucket.main_bucket.id
+  policy = data.aws_iam_policy_document.cloudfront_access_to_main_bucket.json
+}
+

--- a/Terraform/ECR.tf
+++ b/Terraform/ECR.tf
@@ -1,0 +1,13 @@
+resource "aws_ecr_repository" "nextstrain_repo" {
+  name = var.project_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+data "aws_ecr_image" "nextstrain_job" {
+  repository_name = aws_ecr_repository.nextstrain_repo.name
+  image_tag       = "latest"
+}

--- a/Terraform/IAM.tf
+++ b/Terraform/IAM.tf
@@ -1,0 +1,141 @@
+##############################################################################
+##############################################################################
+##
+## IAM permissions that we need to grant to our job containers.
+##
+
+resource "aws_iam_role" "ecs_job_role" {
+  name = "${var.project_name}-job-role"
+  tags = {
+    Project = var.project_name
+  }
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+
+resource "aws_iam_role_policy_attachment" "ecs_job_role_main_bucket" {
+  role       = aws_iam_role.ecs_job_role.name
+  policy_arn = aws_iam_policy.access_to_main_bucket.arn
+}
+
+resource "aws_iam_policy" "access_to_main_bucket" {
+  name        = "${var.project_name}-jobs-access-to-main-bucket"
+  description = "Access to the the main website bucket."
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "VisualEditor0",
+        "Effect": "Allow",
+        "Action": [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:DeleteObject"
+        ],
+        "Resource": [
+          "arn:aws:s3:::${var.main_bucket_name}/auspice/*",
+          "arn:aws:s3:::${var.main_bucket_name}/auspice"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_job_role_invalidate_cloudfront" {
+  role       = aws_iam_role.ecs_job_role.name
+  policy_arn = aws_iam_policy.invalidate_cloudfront.arn
+}
+
+resource "aws_iam_policy" "invalidate_cloudfront" {
+  name        = "${var.project_name}-invalidate-cloudfront"
+  description = "Allow creation of a Cloudfront invalidation."
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "VisualEditor0",
+        "Effect": "Allow",
+        "Action": [
+          "cloudfront:CreateInvalidation"
+        ],
+        "Resource": ["*"]
+      }
+    ]
+  })
+}
+
+
+##############################################################################
+##############################################################################
+##
+## IAM permissions that we need to grant to AWS services (Batch, ECS,
+## Cloudwatch).  These are generally formulaic (AWS-managed policies).
+##
+
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.project_name}-task-role"
+  tags = {
+    Project = var.project_name
+  }
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_role_policy" {
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+
+resource "aws_iam_role" "batch_service_role" {
+  name = "${var.project_name}-batch-service-role"
+  tags = {
+    Project = var.project_name
+  }
+
+  assume_role_policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "batch.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "batch_service_role" {
+  role       = aws_iam_role.batch_service_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+}

--- a/Terraform/IAM.tf
+++ b/Terraform/IAM.tf
@@ -42,10 +42,20 @@ resource "aws_iam_policy" "access_to_main_bucket" {
         "Sid": "VisualEditor0",
         "Effect": "Allow",
         "Action": [
+          "s3:ListBucket"
+        ],
+        "Resource": [
+          "arn:aws:s3:::${var.main_bucket_name}"
+        ]
+      },
+      {
+        "Sid": "VisualEditor1",
+        "Effect": "Allow",
+        "Action": [
           "s3:PutObject",
           "s3:GetObject",
-          "s3:ListBucket",
-          "s3:DeleteObject"
+          "s3:DeleteObject",
+          "s3:CopyObject"
         ],
         "Resource": [
           "arn:aws:s3:::${var.main_bucket_name}/auspice/*",

--- a/Terraform/IAM.tf
+++ b/Terraform/IAM.tf
@@ -94,7 +94,7 @@ resource "aws_iam_policy" "invalidate_cloudfront" {
 ##############################################################################
 ##############################################################################
 ##
-## IAM permissions that we need to grant to AWS services (Batch, ECS,
+## IAM permissions that we need to grant to AWS services (Batch, ECS, EC2
 ## Cloudwatch).  These are generally formulaic (AWS-managed policies).
 ##
 
@@ -148,4 +148,34 @@ resource "aws_iam_role" "batch_service_role" {
 resource "aws_iam_role_policy_attachment" "batch_service_role" {
   role       = aws_iam_role.batch_service_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+
+
+resource "aws_iam_role" "ecs_instance_role" {
+  name = "ecs_instance_role"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+    {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "ec2.amazonaws.com"
+        }
+    }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_role" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_role" {
+  name = "ecs_instance_role"
+  role = aws_iam_role.ecs_instance_role.name
 }

--- a/Terraform/S3.tf
+++ b/Terraform/S3.tf
@@ -1,0 +1,9 @@
+// Website bucket
+data "aws_s3_bucket" "main_bucket" {
+  bucket = var.main_bucket_name
+}
+
+// HTTP access logs bucket
+data "aws_s3_bucket" "logs_bucket" {
+  bucket = var.logs_bucket_name
+}

--- a/Terraform/VPC.tf
+++ b/Terraform/VPC.tf
@@ -1,0 +1,64 @@
+resource "aws_vpc" "main" {
+  cidr_block = var.cidr_block
+  tags = {
+    Name = var.project_name
+    Project = var.project_name
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table" "main" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Project = var.project_name
+  }
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+}
+
+resource "aws_subnet" "subnet" {
+  vpc_id     = aws_vpc.main.id
+  count = var.az_count
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block  = cidrsubnet(aws_vpc.main.cidr_block, 2, count.index)
+  map_public_ip_on_launch = true
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_route_table_association" "a" {
+  count = var.az_count
+  subnet_id = element(aws_subnet.subnet.*.id, count.index)
+  route_table_id = element(aws_route_table.main.*.id, count.index)
+}
+
+resource "aws_network_acl" "main" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_security_group" "outbound_only" {
+  name = "${var.project_name}-outbound-only"
+  vpc_id = aws_vpc.main.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = {
+    Project = var.project_name
+  }
+}

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -1,0 +1,63 @@
+variable "project_name" {
+  type = string
+  description = "The project name, which will be used to construct various resource names."
+  default = "covid-19-puerto-rico-nextstrain"
+}
+
+variable "main_bucket_name" {
+  type = string
+  description = "The name of the base S3 bucket to create/use."
+  default = "covid-19-puerto-rico"
+}
+
+variable "logs_bucket_name" {
+  type = string
+  description = "The name of the bucket to create/use for logs."
+  default = "covid-19-puerto-rico-logs"
+}
+
+variable "jobs_bucket_name" {
+  type = string
+  description = "The name of the Nextstrain CLI jobs bucket to create/use."
+  default = "covid-19-puerto-rico-nextstrain-jobs"
+}
+
+variable "aws_region" {
+  description = "The AWS region things are created in."
+  default     = "us-west-2"
+}
+
+variable "az_count" {
+  description = "Number of AZs to cover in a given region. Depends on the AWS region. Most regions have 3."
+  default     = "4"
+}
+
+variable "cidr_block" {
+  description = "Private IP address range to use."
+  default = "172.32.132.0/22"
+}
+
+variable "iam_user" {
+  description = "Username to attach permissions to in IAM."
+  default = "covid-19-puerto-rico"
+}
+
+variable "vcpus" {
+  description = "How many vCPUs to request per Batch task.  With Fargate, the max is 4."
+  default = 4
+}
+
+variable "memory" {
+  description = "How much memory to request per task. With Fargate, the max is 30720."
+  default = 12288
+}
+
+variable "retry_attempts" {
+  description = "How many times to try tasks in AWS Batch."
+  default = 1  # Just try once
+}
+
+variable "timeout_seconds" {
+  description = "Have AWS Batch kill jobs that exceed this many seconds."
+  default = 21600  # six hours
+}

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -43,13 +43,13 @@ variable "iam_user" {
 }
 
 variable "vcpus" {
-  description = "How many vCPUs to request per Batch task.  With Fargate, the max is 4."
+  description = "How many vCPUs to request per Batch task."
   default = 4
 }
 
 variable "memory" {
-  description = "How much memory to request per task. With Fargate, the max is 30720."
-  default = 12288
+  description = "How much memory to request per task. Usually power-of-two gigs minus 2 gigs."
+  default = 14336
 }
 
 variable "retry_attempts" {

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Build the docker image for the download scripts.
+#
+set -e -o pipefail
+
+PLATFORMS="linux/amd64"
+
+# Some day:
+#PLATFORMS="linux/amd64,linux/arm64"
+
+IMAGE_NAME="${IMAGE_NAME-covid-19-puerto-rico-nextstrain}"
+cd "$(dirname $0)"
+docker buildx build \
+  -t "${IMAGE_NAME}" \
+  --platform "${PLATFORMS}" \
+  .

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,22 +1,13 @@
 #!/usr/bin/env bash
 
-set -e -u -x
+set -e -u
 
 PROFILE="${PROFILE-"puerto-rico_profiles/puerto-rico_open/"}"
+S3_DESTINATION="${S3_DESTINATION:?"S3_DESTINATION not set"}"
+DISTRIBUTION_ID="${DISTRIBUTION_ID:?"DISTRIBUTION_ID not set"}"
+
 snakemake --printshellcmds --profile "${PROFILE}"
-
-if [[ -z "${S3_DESTINATION}" ]]
-then
-  aws s3 sync auspice/ "${S3_DESTINATION}"
-else
-  echo "$(date): No S3_DESTINATION set. Skipping aws s3 sync."
-fi
-
-if [[ -z "${DISTRIBUTION_ID}" ]]
-then
-  aws cloudfront create-invalidation \
-    --distribution-id "${DISTRIBUTION_ID}" \
-    --paths '/*'
-else
-  echo "$(date): No DISTRIBUTION_ID set. Skipping CloudFront invalidation."
-fi
+aws s3 sync auspice/ "${S3_DESTINATION}"
+aws cloudfront create-invalidation \
+  --distribution-id "${DISTRIBUTION_ID}" \
+  --paths '/auspice/*'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,7 +15,7 @@ S3_DESTINATION="${S3_DESTINATION%%+(/)}"
 aws s3 ls "${S3_DESTINATION}"/
 
 snakemake --printshellcmds --profile "${PROFILE}"
-aws s3 sync auspice/ "${S3_DESTINATION}"/
+aws s3 sync --no-progress auspice/ "${S3_DESTINATION}"/
 aws cloudfront create-invalidation \
   --distribution-id "${DISTRIBUTION_ID}" \
   --paths '/auspice/*'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 
-set -e -u
+set -e -u -x
+shopt -s extglob
 
 PROFILE="${PROFILE-"puerto-rico_profiles/puerto-rico_open/"}"
 S3_DESTINATION="${S3_DESTINATION:?"S3_DESTINATION not set"}"
 DISTRIBUTION_ID="${DISTRIBUTION_ID:?"DISTRIBUTION_ID not set"}"
 
+# Remove final slashes
+S3_DESTINATION="${S3_DESTINATION%%+(/)}"
+
+# This is to check that we have the permission to do at least this
+# before we spend 4-6 hours running the build:
+aws s3 ls "${S3_DESTINATION}"/
+
 snakemake --printshellcmds --profile "${PROFILE}"
-aws s3 sync auspice/ "${S3_DESTINATION}"
+aws s3 sync auspice/ "${S3_DESTINATION}"/
 aws cloudfront create-invalidation \
   --distribution-id "${DISTRIBUTION_ID}" \
   --paths '/auspice/*'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e -u -x
+
+PROFILE="${PROFILE-"puerto-rico_profiles/puerto-rico_open/"}"
+snakemake --printshellcmds --profile "${PROFILE}"
+
+if [[ -z "${S3_DESTINATION}" ]]
+then
+  aws s3 sync auspice/ "${S3_DESTINATION}"
+else
+  echo "$(date): No S3_DESTINATION set. Skipping aws s3 sync."
+fi
+
+if [[ -z "${DISTRIBUTION_ID}" ]]
+then
+  aws cloudfront create-invalidation \
+    --distribution-id "${DISTRIBUTION_ID}" \
+    --paths '/*'
+else
+  echo "$(date): No DISTRIBUTION_ID set. Skipping CloudFront invalidation."
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,3 +19,5 @@ aws s3 sync --no-progress auspice/ "${S3_DESTINATION}"/
 aws cloudfront create-invalidation \
   --distribution-id "${DISTRIBUTION_ID}" \
   --paths '/auspice/*'
+
+echo "$(date): All done"

--- a/push-docker-image.sh
+++ b/push-docker-image.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Push the docker image for the download scripts to AWS ECR so that
+# it's available for the Terraform infrastructure.
+#
+# Make sure to set the REPO_ENDPOINT environment variable to your
+# ECR Docker registry hostname, e.g.:
+#
+#     <AWS account #>.dkr.ecr.us-west-2.amazonaws.com
+#
+set -e -o pipefail
+
+IMAGE_NAME="${IMAGE_NAME-covid-19-puerto-rico-nextstrain}"
+ECR_ENDPOINT="${ECR_ENDPOINT:?"ECR_ENDPOINT not set"}"
+
+aws ecr get-login-password --region us-west-2 \
+  | docker login --username AWS --password-stdin "${ECR_ENDPOINT}"
+
+docker tag \
+  "${IMAGE_NAME}":latest \
+  "${ECR_ENDPOINT}"/"${IMAGE_NAME}":latest
+
+docker push "${ECR_ENDPOINT}"/"${IMAGE_NAME}":latest

--- a/run-puerto-rico-build.sh
+++ b/run-puerto-rico-build.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-#
-# This is just to remind me what the command is
-#
-
-exec nextstrain build --aws-batch . \
-  --profile puerto-rico_profiles/puerto-rico_open/


### PR DESCRIPTION
I was using the Nexstrain CLI's ability to run on AWS Batch, but I'm experienced enough with Docker and AWS that it just makes more sense for me to make an image of this project and run it straight as a Batch job. Other improvements that I got in along with this:

1. Automatically synchronize the Auspice output files to the S3 bucket I'm serving them off in CloudFront
2. Switch from Fargate to EC2, for more predictable performance