### PR TITLE
Disable the 6-month dataset build, just do the all-time

### DIFF
--- a/Terraform/Batch.tf
+++ b/Terraform/Batch.tf
@@ -89,8 +89,8 @@ resource "aws_cloudwatch_event_rule" "weekly_run" {
   schedule_expression = "cron(55 09 ? * 1 *)"
 }
 
-resource "aws_cloudwatch_event_target" "weekly_run_6m" {
-  target_id = "covid-19-puerto-rico-nextstrain-6m-run"
+resource "aws_cloudwatch_event_target" "weekly_run" {
+  target_id = "covid-19-puerto-rico-nextstrain-run"
   rule = aws_cloudwatch_event_rule.weekly_run.name
   arn = aws_batch_job_queue.nextstrain_queue.arn
   role_arn = aws_iam_role.ecs_events_role.arn
@@ -105,27 +105,6 @@ resource "aws_cloudwatch_event_target" "weekly_run_6m" {
       "Command": [
         "--profile", "puerto-rico_profiles/puerto-rico_open/",
         "--config", "active_builds=puerto-rico"
-      ]
-    }
-  })
-}
-
-resource "aws_cloudwatch_event_target" "weekly_run_all_time" {
-  target_id = "covid-19-puerto-rico-nextstrain-all-time-run"
-  rule = aws_cloudwatch_event_rule.weekly_run.name
-  arn = aws_batch_job_queue.nextstrain_queue.arn
-  role_arn = aws_iam_role.ecs_events_role.arn
-
-  batch_target {
-    job_definition = aws_batch_job_definition.nextstrain_job.arn
-    job_name       = aws_batch_job_definition.nextstrain_job.name
-  }
-
-  input = jsonencode({
-    "ContainerOverrides": {
-      "Command": [
-        "--profile", "puerto-rico_profiles/puerto-rico_open/",
-        "--config", "active_builds=puerto-rico_all-time"
       ]
     }
   })

--- a/puerto-rico_profiles/puerto-rico_open/builds.yaml
+++ b/puerto-rico_profiles/puerto-rico_open/builds.yaml
@@ -5,18 +5,12 @@ inputs:
     skip_sanitize_metadata: true
 
 builds:
-  puerto-rico_all-time:
-    title: SARS-CoV-2 en Puerto Rico, enfoque desde inicio de la pandemia
+  puerto-rico:
+    title: Filogenia del SARS-CoV-2 en Puerto Rico
     division: Puerto Rico
     country: USA
     region: North America
     subsampling_scheme: divisional_all-time
-  puerto-rico:
-    title: SARS-CoV-2 en Puerto Rico, enfoque en últimos 6 meses
-    division: Puerto Rico
-    country: USA
-    region: North America
-    subsampling_scheme: divisional_6m
 
 
 subsampling:

--- a/puerto-rico_profiles/puerto-rico_open/builds.yaml
+++ b/puerto-rico_profiles/puerto-rico_open/builds.yaml
@@ -28,39 +28,6 @@ subsampling:
       max_sequences: 1000
       query: --query "country != '{country}'"
 
-  divisional_6m:
-    division_late:
-      group_by: "year month"
-      max_sequences: 1500
-      min_date: "--min-date 6M"
-      query: --query "(country == '{country}' & division == '{division}')"
-    country_late:
-      group_by: "division year month"
-      max_sequences: 800
-      min_date: "--min-date 6M"
-      query: --query "(country == '{country}' & division != '{division}')"
-    global_late:
-      group_by: "region year month"
-      max_sequences: 800
-      min_date: "--min-date 6M"
-      query: --query "country != '{country}'"
-
-    division_early:
-      group_by: "year month"
-      max_sequences: 1500
-      max_date: "--max-date 6M"
-      query: --query "(country == '{country}' & division == '{division}')"
-    country_early:
-      group_by: "division year month"
-      max_sequences: 600
-      max_date: "--max-date 6M"
-      query: --query "(country == '{country}' & division != '{division}')"
-    global_early:
-      group_by: "region year month"
-      max_sequences: 600
-      max_date: "--max-date 6M"
-      query: --query "country != '{country}'"
-
 
 # GenBank data includes "Wuhan-Hu-1/2019" which we use as the root for this build
 # as Wuhan/Hu-1/2019 is not in the data.

--- a/puerto-rico_profiles/puerto-rico_open/puerto-rico_description.md
+++ b/puerto-rico_profiles/puerto-rico_open/puerto-rico_description.md
@@ -1,8 +1,4 @@
 Una selección de secuencias genómicas de SARS-CoV-2 de Puerto Rico, con secuencias adicionales
 de otros locales para contextualizar estas.  Todas las secuencias son tomadas de la base de
-datos GenBank.
-
-Existen dos versiones de este análisis, con distintas reglas de muestreo:
-
-* [Prioridad a los 6 meses más recientes](https://nextstrain.org/fetch/covid-19-puerto-rico.org/auspice/ncov_puerto-rico.json?f_division=Puerto%20Rico);
-* [Selección pareja durante toda la pandemia](https://nextstrain.org/fetch/covid-19-puerto-rico.org/auspice/ncov_puerto-rico_all-time.json?f_division=Puerto%20Rico).
+datos GenBank, y el muestreo da peso igual a todos el historial de la pandemia (i.e. no hay
+peso mayor en meses recientes como hacen muchos análisis).


### PR DESCRIPTION
Given how little sequencing is being done for Puerto Rico lately, and how much fewer of it still is deposited to GenBank, we don't need a 6-month dataset apart from the all-time. So just build the latter.